### PR TITLE
bump to minimum supported cmake

### DIFF
--- a/c_src/CMakeLists.txt
+++ b/c_src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5.0 FATAL_ERROR)
 
 project(ErlangRocksDBNIF)
 


### PR DESCRIPTION
There's [another pr for this](https://github.com/EnkiMultimedia/erlang-rocksdb/pull/4) en route to the root repo but I'd rather not wait